### PR TITLE
Initialize ESR-Lab skeleton with spectrum model and CSV parser

### DIFF
--- a/data/examples/sample.csv
+++ b/data/examples/sample.csv
@@ -1,0 +1,7 @@
+# Frequency: 9.5e9
+# ModAmp: 0.001
+# MWPower: 0.2
+Field,Signal
+0.33,0.1
+0.34,0.2
+0.35,0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+PySide6
+pyqtgraph
+pandas
+numpy
+scipy
+lmfit
+matplotlib
+pydantic

--- a/src/esr_lab/__init__.py
+++ b/src/esr_lab/__init__.py
@@ -1,0 +1,5 @@
+"""ESR-Lab package."""
+
+from .core.spectrum import ESRSpectrum, ESRMeta
+
+__all__ = ["ESRSpectrum", "ESRMeta"]

--- a/src/esr_lab/app.py
+++ b/src/esr_lab/app.py
@@ -1,0 +1,30 @@
+"""Minimal ESR-Lab GUI."""
+
+from __future__ import annotations
+
+import sys
+
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QApplication, QLabel, QMainWindow
+
+
+def main() -> int:
+    """Launch the ESR-Lab GUI."""
+    app = QApplication(sys.argv)
+    window = QMainWindow()
+    window.setWindowTitle("ESR-Lab")
+    label = QLabel("ESR-Lab GUI – Under Construction")
+    window.setCentralWidget(label)
+
+    menubar = window.menuBar()
+    file_menu = menubar.addMenu("File")
+    quit_action = QAction("Quit", window)
+    quit_action.triggered.connect(app.quit)
+    file_menu.addAction(quit_action)
+
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/esr_lab/core/__init__.py
+++ b/src/esr_lab/core/__init__.py
@@ -1,0 +1,3 @@
+"""Core modules for ESR-Lab."""
+
+__all__ = []

--- a/src/esr_lab/core/spectrum.py
+++ b/src/esr_lab/core/spectrum.py
@@ -1,0 +1,78 @@
+"""Spectrum data model for ESR-Lab."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+
+class ESRMeta(BaseModel):
+    """Metadata for an ESR spectrum."""
+
+    frequency_Hz: Optional[float] = None
+    mod_amp_T: Optional[float] = None
+    mw_power_W: Optional[float] = None
+    temperature_K: Optional[float] = None
+    phase_rad: Optional[float] = None
+    instrument: Optional[str] = None
+    operator: Optional[str] = None
+    notes: Optional[str] = None
+    timestamp: Optional[datetime] = None
+
+
+class ESRSpectrum(BaseModel):
+    """Core spectrum object holding data and metadata."""
+
+    field_B: np.ndarray
+    signal_dAbs: np.ndarray
+    absorption: Optional[np.ndarray] = None
+    mask: Optional[np.ndarray] = None
+    meta: ESRMeta = Field(default_factory=ESRMeta)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @classmethod
+    def from_bruker_csv(cls, path: str | "Path") -> "ESRSpectrum":
+        """Create a spectrum from a Bruker CSV file."""
+        from pathlib import Path
+
+        from esr_lab.io.bruker_csv import load_bruker_csv
+
+        return load_bruker_csv(Path(path))
+
+    def baseline(self, method: str = "poly", order: int = 2, knots: Optional[np.ndarray] = None) -> "ESRSpectrum":
+        """Placeholder for baseline correction."""
+        return self
+
+    def smooth(self, method: str = "savgol", window: int = 5, polyorder: int = 2) -> "ESRSpectrum":
+        """Placeholder for smoothing."""
+        return self
+
+    def phase_correct(self, delta_rad: float) -> "ESRSpectrum":
+        """Placeholder for phase correction."""
+        return self
+
+    def to_absorption(self) -> "ESRSpectrum":
+        """Placeholder for converting to absorption spectrum."""
+        return self
+
+    def to_area(self) -> float:
+        """Return the area under the spectrum (placeholder)."""
+        return float(np.trapz(self.signal_dAbs, self.field_B))
+
+    def subset(self, Bmin: float, Bmax: float) -> "ESRSpectrum":
+        """Return a subset of the spectrum between ``Bmin`` and ``Bmax``."""
+        mask = (self.field_B >= Bmin) & (self.field_B <= Bmax)
+        return ESRSpectrum(
+            field_B=self.field_B[mask],
+            signal_dAbs=self.signal_dAbs[mask],
+            meta=self.meta,
+        )
+
+    def export_results(self) -> Dict[str, Any]:
+        """Export results as a dictionary (placeholder)."""
+        return self.meta.model_dump() if hasattr(self.meta, "model_dump") else self.meta.dict()

--- a/src/esr_lab/io/__init__.py
+++ b/src/esr_lab/io/__init__.py
@@ -1,0 +1,3 @@
+"""IO utilities for ESR-Lab."""
+
+__all__ = []

--- a/src/esr_lab/io/bruker_csv.py
+++ b/src/esr_lab/io/bruker_csv.py
@@ -1,0 +1,49 @@
+"""Bruker CSV loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+
+from esr_lab.core.spectrum import ESRMeta, ESRSpectrum
+
+
+def load_bruker_csv(path: str | Path) -> ESRSpectrum:
+    """Load a Bruker-format CSV file into an ``ESRSpectrum``."""
+    path = Path(path)
+    header: Dict[str, Any] = {}
+    data_lines: list[str] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if line.startswith("#"):
+                parts = line[1:].strip().split(":", 1)
+                if len(parts) == 2:
+                    key, value = parts
+                    header[key.strip()] = value.strip()
+            else:
+                data_lines.append(line)
+    from io import StringIO
+
+    df = pd.read_csv(StringIO("".join(data_lines)))
+    meta_kwargs: Dict[str, Any] = {}
+    if "Frequency" in header:
+        try:
+            meta_kwargs["frequency_Hz"] = float(header["Frequency"])
+        except ValueError:
+            pass
+    if "ModAmp" in header:
+        try:
+            meta_kwargs["mod_amp_T"] = float(header["ModAmp"])
+        except ValueError:
+            pass
+    if "MWPower" in header:
+        try:
+            meta_kwargs["mw_power_W"] = float(header["MWPower"])
+        except ValueError:
+            pass
+    meta = ESRMeta(**meta_kwargs)
+    field_B = df.iloc[:, 0].to_numpy(dtype=float)
+    signal_dAbs = df.iloc[:, 1].to_numpy(dtype=float)
+    return ESRSpectrum(field_B=field_B, signal_dAbs=signal_dAbs, meta=meta)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,17 @@
+"""Tests for CSV parsers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from esr_lab.io.bruker_csv import load_bruker_csv  # noqa: E402
+
+
+def test_load_bruker_csv() -> None:
+    sample = Path(__file__).resolve().parents[1] / "data" / "examples" / "sample.csv"
+    spectrum = load_bruker_csv(sample)
+    assert spectrum.field_B.size > 0
+    assert spectrum.signal_dAbs.size > 0


### PR DESCRIPTION
## Summary
- add ESRSpectrum and ESRMeta Pydantic models with method stubs
- implement Bruker CSV loader returning ESRSpectrum instances
- provide minimal PySide6 GUI stub and parser test

## Testing
- `python -m pytest tests/test_parsers.py -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689e2a9eb700832495af0455f323ef9d