### PR TITLE
Enable module and script execution for esr_lab

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "ESR-Lab (module)",
+      "type": "python",
+      "request": "launch",
+      "module": "esr_lab.app",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "ESR-Lab (script)",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/src/esr_lab/app.py",
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.analysis.extraPaths": ["${workspaceFolder}/src"]
+}

--- a/src/esr_lab/__init__.py
+++ b/src/esr_lab/__init__.py
@@ -1,5 +1,5 @@
 """ESR-Lab package."""
 
-from .core.spectrum import ESRSpectrum, ESRMeta
+from esr_lab.core.spectrum import ESRSpectrum, ESRMeta
 
 __all__ = ["ESRSpectrum", "ESRMeta"]

--- a/src/esr_lab/__main__.py
+++ b/src/esr_lab/__main__.py
@@ -1,0 +1,4 @@
+from esr_lab.app import main
+
+if __name__ == "__main__":
+    main()

--- a/src/esr_lab/app.py
+++ b/src/esr_lab/app.py
@@ -3,21 +3,28 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
+
+# Ensure 'src' is on sys.path when running as a script: python src/esr_lab/app.py
+_here = Path(__file__).resolve()
+_src = _here.parents[2]  # .../repo/src
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
 
 from PySide6.QtWidgets import QApplication
 
-from .gui.main_window import MainWindow
+from esr_lab.gui.main_window import MainWindow
 
 
-def main() -> int:
+def main() -> None:
     """Launch the ESR-Lab GUI."""
 
     app = QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    return app.exec()
+    app.exec()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual launch
-    raise SystemExit(main())
+    main()
 

--- a/src/esr_lab/core/spectrum.py
+++ b/src/esr_lab/core/spectrum.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Tuple
 import numpy as np
 from pydantic import BaseModel, Field, PrivateAttr
 
-from . import processing
+from esr_lab.core import processing
 
 
 class ESRMeta(BaseModel):

--- a/src/esr_lab/gui/main_window.py
+++ b/src/esr_lab/gui/main_window.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
 from esr_lab.core.spectrum import ESRSpectrum
 from esr_lab.io.bruker_csv import load_bruker_csv
 
-from .plot_view import PlotView
+from esr_lab.gui.plot_view import PlotView
 
 
 class MainWindow(QMainWindow):

--- a/src/esr_lab/io/__init__.py
+++ b/src/esr_lab/io/__init__.py
@@ -1,6 +1,6 @@
 """IO utilities for ESR-Lab."""
 
-from .loader import load_any
-from .bruker_csv import load_bruker_csv
+from esr_lab.io.loader import load_any
+from esr_lab.io.bruker_csv import load_bruker_csv
 
 __all__ = ["load_any", "load_bruker_csv"]

--- a/src/esr_lab/io/loader.py
+++ b/src/esr_lab/io/loader.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from esr_lab.core.spectrum import ESRSpectrum
 
-from . import bruker_csv
+from esr_lab.io import bruker_csv
 
 
 def load_any(path: str | Path) -> ESRSpectrum:


### PR DESCRIPTION
## Summary
- bootstrap `esr_lab.app` so `src` is added to `sys.path` when run as a script
- switch all intra-package imports to absolute imports
- add `__main__.py` and VS Code configs for module/script launches

## Testing
- `python -m pytest -q`
- `PYTHONPATH=src QT_QPA_PLATFORM=offscreen python -m esr_lab.app` *(terminates after 1s; headless run)*
- `QT_QPA_PLATFORM=offscreen python src/esr_lab/app.py` *(fails: libGL.so.1 missing)*
- `apt-get update && apt-get install -y libgl1` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689e3a0109d08324850673dcecb6eae8