### PR TITLE
Default CSV axes to first two columns

### DIFF
--- a/src/esr_lab/io/bruker_csv.py
+++ b/src/esr_lab/io/bruker_csv.py
@@ -254,6 +254,13 @@ def select_axes_from_columns(df: pd.DataFrame) -> Tuple[str, str]:
         x = next(col for col in numeric_cols if col != y_candidates[0])
         return x, y_candidates[0]
 
+    if len(numeric_cols) >= 2:
+        log.info(
+            "Defaulting to first two numeric columns for axes: %s",
+            numeric_cols[:2],
+        )
+        return numeric_cols[0], numeric_cols[1]
+
     log.warning("Ambiguous axis selection, candidates: %s", numeric_cols)
     raise AxisSelectionNeeded(numeric_cols)
 

--- a/tests/test_bruker_csv_loader.py
+++ b/tests/test_bruker_csv_loader.py
@@ -40,17 +40,14 @@ def test_single_column_packed_splits_into_two_columns(tmp_path: Path) -> None:
     assert np.allclose(sp.signal_dAbs, np.array([1.0, 2.0]))
 
 
-def test_axis_selection_dialog_needed_on_ambiguous_columns(tmp_path: Path) -> None:
+def test_ambiguous_columns_default_to_first_two(tmp_path: Path) -> None:
     lines = [
         "Col1,Col2",
         "1,2",
         "3,4",
     ]
     file = _write_file(tmp_path / "amb.csv", lines)
-    try:
-        bruker_csv.load_bruker_csv(file)
-    except bruker_csv.AxisSelectionNeeded:
-        pass
-    else:
-        raise AssertionError("AxisSelectionNeeded not raised")
+    sp = bruker_csv.load_bruker_csv(file)
+    assert np.allclose(sp.field_B, np.array([1.0, 3.0]))
+    assert np.allclose(sp.signal_dAbs, np.array([2.0, 4.0]))
 


### PR DESCRIPTION
## Summary
- Default ambiguous CSV axis selection to the first two numeric columns, assuming field vs absorption
- Add regression test for ambiguous CSVs to ensure they load without manual axis mapping

## Testing
- `pytest tests/test_bruker_csv_loader.py -q`
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f8499b3b88324b680773c541fd5bb