### PR TITLE
Raise error when Y column missing in CSV loader

### DIFF
--- a/src/esr_lab/io/bruker_csv.py
+++ b/src/esr_lab/io/bruker_csv.py
@@ -276,6 +276,8 @@ def resolve_axes(df: pd.DataFrame) -> tuple[str, str, dict]:
         y_col = next((cand for cand in signal_candidates if cand != x_col), None)
         if y_col is None:
             y_col = next((cand for cand in data_numeric if cand != x_col), None)
+        if y_col is None:
+            raise ValueError("No valid Y column found")
     # Case C: exactly two data columns
     elif len(data_numeric) == 2:
         a, b = data_numeric

--- a/tests/test_bruker_csv_loader.py
+++ b/tests/test_bruker_csv_loader.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
@@ -41,4 +42,11 @@ def test_ambiguous_columns_default_to_first_two(tmp_path: Path) -> None:
     assert sp.field_B.size == 10
     assert np.allclose(sp.field_B, np.arange(1.0, 20.0, 2))
     assert np.allclose(sp.signal_dAbs, np.arange(2.0, 22.0, 2))
+
+
+def test_missing_signal_column_raises(tmp_path: Path) -> None:
+    lines = ["BField,[mT]"] + [f"{i*100},1" for i in range(1, 6)]
+    file = _write_file(tmp_path / "no_signal.csv", lines)
+    with pytest.raises(ValueError):
+        bruker_csv.load_bruker_csv(file)
 


### PR DESCRIPTION
## Summary
- ensure Bruker CSV loader raises a clear error when only a field column is present
- add regression test for files lacking a signal column

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74f24d0c0832481aa828fd9d48103