### PR TITLE
Raise error when pyqtgraph is missing

### DIFF
--- a/src/esr_lab/gui/main_window.py
+++ b/src/esr_lab/gui/main_window.py
@@ -24,7 +24,7 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("ESR-Lab")
 
         self.log = get_logger(__name__)
-        self.plot = PlotView(log=self.log)
+        self.plot = PlotView(log=self.log, raise_if_missing=True)
         self.setCentralWidget(self.plot)
 
         self._spectra: List[ESRSpectrum] = []

--- a/src/esr_lab/gui/plot_view.py
+++ b/src/esr_lab/gui/plot_view.py
@@ -30,7 +30,7 @@ if pg is None:  # pragma: no cover - fallback implementation
             self.log = log or get_logger(__name__)
             if raise_if_missing:
                 raise RuntimeError(
-                    "pyqtgraph not installed; plotting disabled",
+                    "pyqtgraph not installed; install with 'pip install pyqtgraph' to enable plotting",
                 )
 
         def set_background(self, clear: bool = True) -> None:  # noqa: D401 - no-op
@@ -82,7 +82,9 @@ if pg is None:  # pragma: no cover - fallback implementation
             pass
 
     # Warn users at import time that plotting is disabled
-    get_logger(__name__).warning("pyqtgraph not installed; plotting disabled")
+    get_logger(__name__).warning(
+        "pyqtgraph not installed; install with 'pip install pyqtgraph' to enable plotting",
+    )
 
 else:
 


### PR DESCRIPTION
## Summary
- ensure plotting fails fast when pyqtgraph is absent
- guide users to install pyqtgraph if plotting backend is missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a766d5f5f88324812184a9c61a74d1