### PR TITLE
Add runtime dependencies in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,16 @@ build-backend = "setuptools.build_meta"
 name = "esr-lab"
 version = "0.0.1"
 requires-python = ">=3.10"
+dependencies = [
+    "PySide6",
+    "pyqtgraph",
+    "pandas",
+    "numpy",
+    "scipy",
+    "lmfit",
+    "matplotlib",
+    "pydantic",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary
- Declare required runtime dependencies in `pyproject.toml`

## Testing
- `pytest -q`
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a766d6e1ec8324bd2d2bc548e3070c