### PR TITLE
Fix derivative plot pen rendering

### DIFF
--- a/src/esr_lab/gui/plot_view.py
+++ b/src/esr_lab/gui/plot_view.py
@@ -139,7 +139,8 @@ else:
                 self.clear()
             x, y = self._validate_xy(sp.field_B, sp.signal_dAbs)
             self.setLabel("left", "d(Abs)/dB (arb.)")
-            self.plot(x, y, pen=None, name=name)
+            # Use a visible pen so the derivative trace renders as a line
+            self.plot(x, y, pen=pg.mkPen(), name=name)
 
         # ------------------------------------------------------------------
         def plot_absorption(


### PR DESCRIPTION
## Summary
- ensure derivative plot uses a visible line pen so derivative spectrum renders

## Testing
- `pytest -q`
- `PYTHONPATH=src QT_QPA_PLATFORM=offscreen timeout 5 python -m esr_lab.app` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b1c6d38832487faf5bd7a929ab4