### PR TITLE
Fix PlotView auto_range to disable continuous auto scaling

### DIFF
--- a/src/esr_lab/gui/plot_view.py
+++ b/src/esr_lab/gui/plot_view.py
@@ -179,6 +179,8 @@ else:
             """Auto scale the view to show all data."""
 
             self.plotItem.enableAutoRange("xy", True)
+            self.plotItem.autoRange()
+            self.plotItem.enableAutoRange("xy", False)
 
 
 __all__ = ["PlotView"]


### PR DESCRIPTION
## Summary
- Auto-range the plot once and then disable further auto scaling

## Testing
- `pytest -q`
- `PYTHONPATH=src python -m esr_lab.app` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7800e8dfc8324b329bc8cb4ac741e