### PR TITLE
Raise error when plotting deps missing

### DIFF
--- a/src/frontend/gui/main_window.py
+++ b/src/frontend/gui/main_window.py
@@ -7,7 +7,7 @@ from typing import List
 
 from PySide6.QtCore import Qt, QEvent, QUrl
 from PySide6.QtGui import QAction, QDesktopServices
-from PySide6.QtWidgets import QFileDialog, QMainWindow
+from PySide6.QtWidgets import QFileDialog, QMainWindow, QMessageBox
 
 from backend.core.spectrum import ESRSpectrum
 from backend.io import loader
@@ -24,7 +24,16 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("ESR-Lab")
 
         self.log = get_logger(__name__)
-        self.plot = PlotView(log=self.log, raise_if_missing=True)
+        try:
+            self.plot = PlotView(log=self.log, raise_if_missing=True)
+        except RuntimeError as e:
+            QMessageBox.critical(
+                self,
+                "Plotting Unavailable",
+                "Plotting requires the 'PySide6' and 'pyqtgraph' packages.",
+            )
+            self.log.error("Plot initialization failed: %s", e)
+            raise
         self.setCentralWidget(self.plot)
 
         self._spectra: List[ESRSpectrum] = []

--- a/tests/test_logging_and_validation.py
+++ b/tests/test_logging_and_validation.py
@@ -10,6 +10,9 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+pytest.importorskip("PySide6")
+pytest.importorskip("pyqtgraph")
+
 from frontend.gui.plot_view import PlotView
 from backend.io import loader
 

--- a/tests/test_open_and_plot.py
+++ b/tests/test_open_and_plot.py
@@ -44,6 +44,7 @@ def test_loader_parses_example_csv(tmp_path: Path) -> None:
 
 def test_plot_view_handles_single_and_overlay(qtbot) -> None:  # type: ignore[ann-type]
     pytest.importorskip("PySide6")
+    pytest.importorskip("pyqtgraph")
     from frontend.gui.plot_view import PlotView
 
     view = PlotView()


### PR DESCRIPTION
## Summary
- replace PlotView fallback with stub that raises when PySide6/pyqtgraph are unavailable
- warn users at startup by catching PlotView initialization errors and showing a QMessageBox
- adjust tests to skip when optional GUI dependencies are absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a885a9f6c483248cf6520fdd449988