### PR TITLE
Refactor physics tests with dedicated logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ lmfit
 matplotlib
 pydantic
 pytest-qt
+libgl1

--- a/tests/test_physics.py
+++ b/tests/test_physics.py
@@ -1,33 +1,81 @@
+"""Tests for :mod:`backend.core.physics`."""
+
+import logging
+from pathlib import Path
+
 import numpy as np
 import pytest
 from scipy.constants import hbar, physical_constants
 
 from backend.core import physics
+from backend.utils.logging import get_logger
 
 mu_B = physical_constants["Bohr magneton"][0]
 
 
-def test_linewidth_conversions() -> None:
+@pytest.fixture
+def physics_logger(tmp_path: Path) -> logging.Logger:
+    """Logger writing to a temporary file for each test."""
+
+    log_path = tmp_path / "physics.log"
+    logger = get_logger("test_physics")
+    logger.handlers.clear()
+    handler = logging.FileHandler(log_path)
+    formatter = logging.Formatter("%(levelname)s | %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    yield logger
+    for h in list(logger.handlers):
+        h.flush()
+        h.close()
+    logger.handlers.clear()
+
+
+def test_fwhm_from_pp_lorentz(physics_logger: logging.Logger) -> None:
     dBpp = 1e-3
-    fwhm_l = physics.fwhm_from_pp_lorentz(dBpp)
-    fwhm_g = physics.fwhm_from_pp_gauss(dBpp)
-    assert pytest.approx(np.sqrt(3) * dBpp, rel=1e-12) == fwhm_l
-    assert pytest.approx(1.177 * dBpp, rel=1e-12) == fwhm_g
+    expected = np.sqrt(3) * dBpp
+    result = physics.fwhm_from_pp_lorentz(dBpp)
+    physics_logger.info("Lorentz FWHM expected %s computed %s", expected, result)
+    assert pytest.approx(expected, rel=1e-12) == result
 
 
-def test_hyperfine_and_gamma() -> None:
-    A = physics.hyperfine_A_MHz_from_spacing(1.0, 2.0)
-    assert pytest.approx(56.0499, rel=1e-4) == A
-    gamma = physics.gamma_from_g(2.0)
-    assert pytest.approx(2.0 * mu_B / hbar, rel=1e-12) == gamma
+def test_fwhm_from_pp_gauss(physics_logger: logging.Logger) -> None:
+    dBpp = 1e-3
+    expected = 1.177 * dBpp
+    result = physics.fwhm_from_pp_gauss(dBpp)
+    physics_logger.info("Gaussian FWHM expected %s computed %s", expected, result)
+    assert pytest.approx(expected, rel=1e-12) == result
 
 
-def test_T2_from_fwhm_lorentz() -> None:
+def test_hyperfine_A_MHz_from_spacing(physics_logger: logging.Logger) -> None:
+    expected = 2.0 * 28.02495 * 1.0
+    result = physics.hyperfine_A_MHz_from_spacing(1.0, 2.0)
+    physics_logger.info("Hyperfine A expected %s computed %s", expected, result)
+    assert pytest.approx(expected, rel=1e-4) == result
+
+
+def test_gamma_from_g(physics_logger: logging.Logger) -> None:
+    expected = 2.0 * mu_B / hbar
+    result = physics.gamma_from_g(2.0)
+    physics_logger.info("Gamma expected %s computed %s", expected, result)
+    assert pytest.approx(expected, rel=1e-12) == result
+
+
+def test_g_factor(physics_logger: logging.Logger) -> None:
+    expected = 2.0
+    result = physics.g_factor(9.5e9, 0.339)
+    physics_logger.info("g-factor expected %s computed %s", expected, result)
+    assert pytest.approx(expected, rel=1e-2) == result
+
+
+def test_T2_from_fwhm_lorentz(physics_logger: logging.Logger) -> None:
     g = 2.0
     fwhm = 1e-3
-    T2 = physics.T2_from_fwhm_lorentz(fwhm, g)
+    result = physics.T2_from_fwhm_lorentz(fwhm, g)
     gamma = physics.gamma_from_g(g)
-    assert pytest.approx(1 / (gamma * fwhm), rel=1e-12) == T2
+    expected = 1 / (gamma * fwhm)
+    physics_logger.info("T2 expected %s computed %s", expected, result)
+    assert pytest.approx(expected, rel=1e-12) == result
     with pytest.raises(ValueError):
         physics.T2_from_fwhm_lorentz(-1.0, g)
     with pytest.raises(ValueError):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from backend.core import processing, physics, units
+from backend.core import processing, units
 
 
 def test_poly_baseline_removes_trend() -> None:
@@ -55,8 +55,3 @@ def test_units_conversions_roundtrip() -> None:
     w = units.mw_to_w(mw)
     mw_back = units.w_to_mw(w)
     assert pytest.approx(mw, rel=1e-12) == mw_back
-
-
-def test_g_factor_numeric() -> None:
-    g = physics.g_factor(9.5e9, 0.339)
-    assert pytest.approx(2.0, rel=1e-2) == g


### PR DESCRIPTION
## Summary
- split physics tests into one test per function and move g-factor coverage into this module
- add logging fixture writing to a temp file for each test
- keep T2 test with error handling
- declare libGL system dependency in requirements

## Testing
- `apt-get update && apt-get install -y libgl1` *(fails: repository not signed / package not found)*
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a88a9ce0b4832481ee439b36ace636